### PR TITLE
Specify MIT license in the gemspec

### DIFF
--- a/capistrano-harrow.gemspec
+++ b/capistrano-harrow.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{A plugin to improve the user experience for users of Capistrano and Harrow}
   spec.description   = %q{Hooks to allow people experiencing problems with Capistrano to register with a service to get help and have a smoother workflow.}
   spec.homepage      = "https://github.com/harrowio/capistrano-harrow"
+  spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"


### PR DESCRIPTION
We're using [`license_finder`](https://github.com/pivotal/LicenseFinder) to check the licenses of our dependencies and `capistrano-harrow` came up with an "unknown" license. I see from `LICENSE.txt` and https://github.com/harrowio/capistrano-harrow/issues/2 that this project is under a MIT license, so hopefully you find this PR useful.